### PR TITLE
Added more identity EFxceptionsContext types

### DIFF
--- a/EFxceptions.Identity/EFxceptionsIdentityContext.cs
+++ b/EFxceptions.Identity/EFxceptionsIdentityContext.cs
@@ -4,16 +4,51 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using EFxceptions.Brokers;
 using EFxceptions.Services;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace EFxceptions.Identity
 {
-    public class EFxceptionsContext : IdentityDbContext
+    public class EFxceptionsContext<TUser> : IdentityDbContext<TUser, IdentityRole, string> where TUser : IdentityUser
+    {
+        protected EFxceptionsContext()
+        {
+        }
+
+        public EFxceptionsContext(DbContextOptions options) : base(options)
+        {
+        }
+    }
+
+    public class EFxceptionsContext<TUser, TRole, TKey> : EFxceptionsContext<TUser, TRole, TKey, IdentityUserClaim<TKey>, IdentityUserRole<TKey>, IdentityUserLogin<TKey>, IdentityRoleClaim<TKey>, IdentityUserToken<TKey>>
+        where TUser : IdentityUser<TKey>
+        where TRole : IdentityRole<TKey>
+        where TKey : IEquatable<TKey>
+    {
+        protected EFxceptionsContext()
+        {
+        }
+
+        public EFxceptionsContext(DbContextOptions options) : base(options)
+        {
+        }
+    }
+
+    public class EFxceptionsContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken> : IdentityDbContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
+        where TUser : IdentityUser<TKey>
+        where TRole : IdentityRole<TKey>
+        where TKey : IEquatable<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserToken : IdentityUserToken<TKey>
     {
         private IEFxceptionService eFxceptionService;
         private ISqlErrorBroker sqlErrorBroker;
@@ -21,7 +56,7 @@ namespace EFxceptions.Identity
         protected EFxceptionsContext() =>
             InitializeInternalServices();
 
-        public EFxceptionsContext(DbContextOptions<EFxceptionsContext> options) : base(options) =>
+        public EFxceptionsContext(DbContextOptions options) : base(options) =>
             InitializeInternalServices();
 
         private void InitializeInternalServices()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We have designed and developed this library as a wrapper around the existing Ent
 
 # EFxeptions.Identity
 
-A dedicated EFxeptions port that provides an `IDentityDbContext` to inherit from, support Microsoft ASP.Core Identity using EF Core.
+A dedicated EFxeptions port that provides an `EFxceptionContext` that inherits from `Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext` to inherit from, to support Microsoft ASP.Core Identity using EF Core.
 Available in the [EFxceptions.Identity](https://www.nuget.org/packages/EFxceptions.Identity) package.
 
 ## Installation 


### PR DESCRIPTION
This PR adds additional `IdentityDbContext` types of different generic arguments.