### PR TITLE
Add .NET Standard 2.1 target with higher package versions

### DIFF
--- a/EFxceptions.Identity/EFxceptions.Identity.csproj
+++ b/EFxceptions.Identity/EFxceptions.Identity.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.4.3</Version>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <Version>0.4.4</Version>
     <Description>EFxceptions is a .NET Standard library that captures the exceptions thrown by the EntityFramework from a SQL server and converts them into meaningful exceptions.</Description>
     <Copyright>Copyright (c) Hassan Habib, Alice Luo and Shimmy Weitzhandler  All rights reserved.</Copyright>
     <PackageLicenseFile>License.txt</PackageLicenseFile>
@@ -10,21 +10,27 @@
     <RepositoryUrl>https://github.com/hassanhabib/EFxceptions</RepositoryUrl>
     <RepositoryType>github</RepositoryType>
     <PackageTags>Exceptions EntityFramework</PackageTags>
-    <PackageReleaseNotes>- Downgrade dependent packages to allow for a broader audience</PackageReleaseNotes>
+    <PackageReleaseNotes>Use latest NuGet dependencies</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIcon>EFxceptions.png</PackageIcon>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Hassan Habib, Alice Luo and Shimmy Weitzhandler</Authors>
     <Company>Piorsoft, LLC</Company>
-    <AssemblyVersion>0.4.3.0</AssemblyVersion>
-    <FileVersion>0.4.3.0</FileVersion>
+    <AssemblyVersion>0.4.4.0</AssemblyVersion>
+    <FileVersion>0.4.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EFxceptions/EFxceptions.csproj
+++ b/EFxceptions/EFxceptions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.4.3</Version>
+    <Version>0.4.4</Version>
     <Description>EFxceptions is a .NET Standard library that captures the exceptions thrown by the EntityFramework from a SQL server and converts them into meaningful exceptions.</Description>
     <Copyright>Copyright (c) Hassan Habib, Alice Luo and Shimmy Weitzhandler  All rights reserved.</Copyright>
     <PackageLicenseFile>License.txt</PackageLicenseFile>
@@ -10,21 +10,20 @@
     <RepositoryUrl>https://github.com/hassanhabib/EFxceptions</RepositoryUrl>
     <RepositoryType>github</RepositoryType>
     <PackageTags>Exceptions EntityFramework</PackageTags>
-    <PackageReleaseNotes>- Remove unnecessary reference to Identity
-- Downgrade dependent packages to allow for a broader audience</PackageReleaseNotes>
+    <PackageReleaseNotes>Use latest NuGet dependencies</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageIcon>EFxceptions.png</PackageIcon>
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>Hassan Habib, Alice Luo and Shimmy Weitzhandler</Authors>
     <Company>Piorsoft, LLC</Company>
-    <AssemblyVersion>0.4.3.0</AssemblyVersion>
-    <FileVersion>0.4.3.0</FileVersion>
+    <AssemblyVersion>0.4.4.0</AssemblyVersion>
+    <FileVersion>0.4.4.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Currently, Identity has two targets and uses different versions for .NET Standard 2.0 and 2.1.
This means we cannot use Identity's newer versions in .NET Standard 2.1 projects (including ASP.NET Core 3.1).

This PR addresses that. It also advances the package version to 0.4.4.