### PR TITLE
FOUNDATIONS: Added max length exception

### DIFF
--- a/EFxceptions.Shared/EFxceptions.Shared.projitems
+++ b/EFxceptions.Shared/EFxceptions.Shared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\Exceptions\ForeignKeyConstraintConflictException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Exceptions\InvalidColumnNameException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Exceptions\InvalidObjectNameException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\Exceptions\MaxLengthException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\EFxceptionService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\EFxceptionService.Exceptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Services\EFxceptionService.Validations.cs" />

--- a/EFxceptions.Shared/Models/Exceptions/MaxLengthException.cs
+++ b/EFxceptions.Shared/Models/Exceptions/MaxLengthException.cs
@@ -1,0 +1,14 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) Hassan Habib, Francis Adediran, Alice Luo and Shimmy Weitzhandler  All rights reserved.
+// Licensed under the MIT License.
+// See License.txt in the project root for license information.
+// ---------------------------------------------------------------
+using System;
+
+namespace EFxceptions.Models.Exceptions
+{
+    public class MaxLengthException : Exception
+    {
+        public MaxLengthException(string message) : base(message) { }
+    }
+}

--- a/EFxceptions.Shared/Services/EFxceptionService.Exceptions.cs
+++ b/EFxceptions.Shared/Services/EFxceptionService.Exceptions.cs
@@ -23,7 +23,9 @@ namespace EFxceptions.Services
                 case 2601:
                     throw new DuplicateKeyWithUniqueIndexException(message);
                 case 2627:
-                    throw new DuplicateKeyException(message); 
+                    throw new DuplicateKeyException(message);
+                case 8152:
+                    throw new MaxLengthException(message);
             }
         }
     }

--- a/EFxceptions.Tests/Services/EFxceptionServiceTests.cs
+++ b/EFxceptions.Tests/Services/EFxceptionServiceTests.cs
@@ -169,6 +169,27 @@ namespace EFxceptions.Tests.Services
                     Times.Never);
         }
 
+        [Fact]
+        public void ShouldThrowMaxLengthException()
+        {
+            // given
+            int maxLengthErrorCode = 8152;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            SqlException maxLengthSqlException = CreateSqlException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: maxLengthSqlException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(maxLengthSqlException))
+                    .Returns(maxLengthErrorCode);
+
+            // when . then
+            Assert.Throws<MaxLengthException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
         private SqlException CreateSqlException() =>
             FormatterServices.GetUninitializedObject(typeof(SqlException)) as SqlException;
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ SQL server supports over [41,000 error codes](https://docs.microsoft.com/en-us/s
 |208|Invalid object name '%.*ls'.|InvalidObjectNameException|
 |547|The %ls statement conflicted with the %ls constraint "%.*ls". The conflict occurred in database "%.*ls", table "%.*ls"%ls%.*ls%ls.|ForeignKeyConstraintConflictException|
 |2627|Violation of %ls constraint '%.*ls'. Cannot insert duplicate key in object '%.*ls'.|DuplicateKeyException|
+|8152|String or binary data would be truncated.|MaxLengthException|
 
 
 <br >


### PR DESCRIPTION
I'm migrating legacy code to use new EF. experienced this whilst running acceptance tests that inserts a large string into a column with restricted length.


8152| 16 | No | String or binary data would be truncated.