### PR TITLE
Fixing issue #31

### DIFF
--- a/EFxceptions.Identity.Tests/EFxceptionServiceTests.MySql.cs
+++ b/EFxceptions.Identity.Tests/EFxceptionServiceTests.MySql.cs
@@ -10,6 +10,7 @@ using EFxceptions.Services;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Moq;
+using MySql.Data.MySqlClient;
 using System;
 using System.Runtime.Serialization;
 using Tynamix.ObjectFiller;
@@ -19,22 +20,14 @@ namespace EFxceptions.Identity.Tests
 {
     public partial class EFxceptionServiceTests
     {
-        private readonly Mock<ISqlErrorBroker> sqlErrorBrokerMock;
-        private readonly IEFxceptionService efxceptionService;
-
-        public EFxceptionServiceTests()
-        {
-            this.sqlErrorBrokerMock = new Mock<ISqlErrorBroker>();
-            this.efxceptionService = new EFxceptionService(this.sqlErrorBrokerMock.Object);
-        }
-
+       
         [Fact]
-        public void ShouldThrowDbUpdateExceptionIfErrorCodeIsNotRecognized()
+        public void ShouldThrowDbUpdateExceptionIfErrorCodeIsNotRecognized_MySql()
         {
             // given
             int sqlForeignKeyConstraintConflictErrorCode = 0000;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException foreignKeyConstraintConflictException = CreateSqlException();
+            MySqlException foreignKeyConstraintConflictException = CreateMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
@@ -50,12 +43,12 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowInvalidColumnNameException()
+        public void ShouldThrowInvalidColumnNameException_MySql()
         {
             // given
             int sqlInvalidColumnNameErrorCode = 207;
             string randomErrorMessage = CreateRandomErrorMessage();
-            SqlException invalidColumnNameException = CreateSqlException();
+            MySqlException invalidColumnNameException = CreateMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
@@ -71,12 +64,12 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowInvalidObjectNameException()
+        public void ShouldThrowInvalidObjectNameException_MySql()
         {
             // given
             int sqlInvalidObjectNameErrorCode = 208;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException invalidObjectNameException = CreateSqlException();
+            MySqlException invalidObjectNameException = CreateMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
@@ -92,12 +85,12 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowForeignKeyConstraintConflictException()
+        public void ShouldThrowForeignKeyConstraintConflictException_MySql()
         {
             // given
             int sqlForeignKeyConstraintConflictErrorCode = 547;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException foreignKeyConstraintConflictException = CreateSqlException();
+            MySqlException foreignKeyConstraintConflictException = CreateMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
@@ -113,19 +106,19 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowDuplicateKeyWithUniqueIndexException()
+        public void ShouldThrowDuplicateKeyWithUniqueIndexException_MySql()
         {
             // given
             int sqlDuplicateKeyErrorCode = 2601;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException duplicateKeySqlException = CreateSqlException();
+            MySqlException duplicateKeyMySqlException = CreateMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
-                innerException: duplicateKeySqlException);
+                innerException: duplicateKeyMySqlException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetErrorCode(duplicateKeySqlException))
+                broker.GetErrorCode(duplicateKeyMySqlException))
                     .Returns(sqlDuplicateKeyErrorCode);
 
             // when . then
@@ -134,19 +127,19 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowDuplicateKeyException()
+        public void ShouldThrowDuplicateKeyException_MySql()
         {
             // given
             int sqlDuplicateKeyErrorCode = 2627;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException duplicateKeySqlException = CreateSqlException();
+            MySqlException duplicateKeyMySqlException = CreateMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
-                innerException: duplicateKeySqlException);
+                innerException: duplicateKeyMySqlException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetErrorCode(duplicateKeySqlException))
+                broker.GetErrorCode(duplicateKeyMySqlException))
                     .Returns(sqlDuplicateKeyErrorCode);
 
             // when . then
@@ -155,7 +148,7 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowDbUpdateExceptionIfSqlExceptionWasNull()
+        public void ShouldThrowDbUpdateExceptionIfMySqlExceptionWasNull_MySql()
         {
             // given
             var dbUpdateException = new DbUpdateException(null, default(Exception));
@@ -165,13 +158,12 @@ namespace EFxceptions.Identity.Tests
                 this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
 
             this.sqlErrorBrokerMock.Verify(broker =>
-                broker.GetErrorCode(It.IsAny<SqlException>()),
+                broker.GetErrorCode(It.IsAny<MySqlException>()),
                     Times.Never);
         }
 
-        private SqlException CreateSqlException() =>
-            FormatterServices.GetUninitializedObject(typeof(SqlException)) as SqlException;
-
-        private string CreateRandomErrorMessage() => new MnemonicString().GetValue();
+        private MySqlException CreateMySqlException() =>
+            FormatterServices.GetUninitializedObject(typeof(MySqlException)) as MySqlException;
+         
     }
 }

--- a/EFxceptions.Identity/EFxceptions.Identity.csproj
+++ b/EFxceptions.Identity/EFxceptions.Identity.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="MySql.Data" Version="8.0.28" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/EFxceptions.Identity/EFxceptionsIdentityContext.cs
+++ b/EFxceptions.Identity/EFxceptionsIdentityContext.cs
@@ -4,14 +4,14 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using EFxceptions.Brokers;
 using EFxceptions.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EFxceptions.Identity
 {

--- a/EFxceptions.Infrastructure.Build/Program.cs
+++ b/EFxceptions.Infrastructure.Build/Program.cs
@@ -71,6 +71,6 @@ var githubPipeLine = new GithubPipeline
 var client = new ADotNetClient();
 
 client.SerializeAndWriteToFile(
-    adoPipeline: githubPipeLine, 
+    adoPipeline: githubPipeLine,
     path: "../../../../.github/workflows/dotnet.yml");
 

--- a/EFxceptions.Shared/Brokers/ISqlErrorBroker.cs
+++ b/EFxceptions.Shared/Brokers/ISqlErrorBroker.cs
@@ -4,12 +4,12 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
-using Microsoft.Data.SqlClient;
+using System.Data.Common;
 
 namespace EFxceptions.Brokers
 {
     public interface ISqlErrorBroker
     {
-        int GetSqlErrorCode(SqlException sqlException);
+        int GetErrorCode(DbException dbException);
     }
 }

--- a/EFxceptions.Shared/Brokers/SqlErrorBroker.cs
+++ b/EFxceptions.Shared/Brokers/SqlErrorBroker.cs
@@ -5,11 +5,22 @@
 // ---------------------------------------------------------------
 
 using Microsoft.Data.SqlClient;
+using MySql.Data.MySqlClient;
+using System.Data.Common;
 
 namespace EFxceptions.Brokers
 {
     public class SqlErrorBroker : ISqlErrorBroker
     {
-        public int GetSqlErrorCode(SqlException sqlException) => sqlException.Number;
+        public int GetErrorCode(DbException exception)
+        {
+            if (exception is MySqlException mySqlException)
+            {
+                return mySqlException.Number;
+            }
+
+            return ((SqlException)exception).Number;
+        }
+
     }
 }

--- a/EFxceptions.Shared/Services/EFxceptionService.Exceptions.cs
+++ b/EFxceptions.Shared/Services/EFxceptionService.Exceptions.cs
@@ -23,7 +23,7 @@ namespace EFxceptions.Services
                 case 2601:
                     throw new DuplicateKeyWithUniqueIndexException(message);
                 case 2627:
-                    throw new DuplicateKeyException(message); 
+                    throw new DuplicateKeyException(message);
             }
         }
     }

--- a/EFxceptions.Tests/Services/EFxceptionServiceTests.MySql.cs
+++ b/EFxceptions.Tests/Services/EFxceptionServiceTests.MySql.cs
@@ -10,31 +10,25 @@ using EFxceptions.Services;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Moq;
+using MySql.Data.MySqlClient;
 using System;
 using System.Runtime.Serialization;
 using Tynamix.ObjectFiller;
 using Xunit;
 
-namespace EFxceptions.Identity.Tests
+namespace EFxceptions.Tests.Services
 {
-    public partial class EFxceptionServiceTests
+    public  partial class EFxceptionServiceTests
     {
-        private readonly Mock<ISqlErrorBroker> sqlErrorBrokerMock;
-        private readonly IEFxceptionService efxceptionService;
-
-        public EFxceptionServiceTests()
-        {
-            this.sqlErrorBrokerMock = new Mock<ISqlErrorBroker>();
-            this.efxceptionService = new EFxceptionService(this.sqlErrorBrokerMock.Object);
-        }
+          
 
         [Fact]
-        public void ShouldThrowDbUpdateExceptionIfErrorCodeIsNotRecognized()
+        public void ShouldThrowDbUpdateExceptionIfErrorCodeIsNotRecognized_MySql()
         {
             // given
             int sqlForeignKeyConstraintConflictErrorCode = 0000;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException foreignKeyConstraintConflictException = CreateSqlException();
+            MySqlException foreignKeyConstraintConflictException = CreateMyMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
@@ -50,12 +44,12 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowInvalidColumnNameException()
+        public void ShouldThrowInvalidColumnNameException_MySql()
         {
             // given
             int sqlInvalidColumnNameErrorCode = 207;
             string randomErrorMessage = CreateRandomErrorMessage();
-            SqlException invalidColumnNameException = CreateSqlException();
+            MySqlException invalidColumnNameException = CreateMyMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
@@ -71,12 +65,12 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowInvalidObjectNameException()
+        public void ShouldThrowInvalidObjectNameException_MySql()
         {
             // given
             int sqlInvalidObjectNameErrorCode = 208;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException invalidObjectNameException = CreateSqlException();
+            MySqlException invalidObjectNameException = CreateMyMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
@@ -92,12 +86,12 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowForeignKeyConstraintConflictException()
+        public void ShouldThrowForeignKeyConstraintConflictException_MySql()
         {
             // given
             int sqlForeignKeyConstraintConflictErrorCode = 547;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException foreignKeyConstraintConflictException = CreateSqlException();
+            MySqlException foreignKeyConstraintConflictException = CreateMyMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
@@ -113,19 +107,19 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowDuplicateKeyWithUniqueIndexException()
+        public void ShouldThrowDuplicateKeyWithUniqueIndexException_MySql()
         {
             // given
             int sqlDuplicateKeyErrorCode = 2601;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException duplicateKeySqlException = CreateSqlException();
+            MySqlException duplicateKeyMySqlException = CreateMyMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
-                innerException: duplicateKeySqlException);
+                innerException: duplicateKeyMySqlException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetErrorCode(duplicateKeySqlException))
+                broker.GetErrorCode(duplicateKeyMySqlException))
                     .Returns(sqlDuplicateKeyErrorCode);
 
             // when . then
@@ -134,19 +128,19 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowDuplicateKeyException()
+        public void ShouldThrowDuplicateKeyException_MySql()
         {
             // given
             int sqlDuplicateKeyErrorCode = 2627;
             string randomErrorMessage = new MnemonicString().GetValue();
-            SqlException duplicateKeySqlException = CreateSqlException();
+            MySqlException duplicateKeyMySqlException = CreateMyMySqlException();
 
             var dbUpdateException = new DbUpdateException(
                 message: randomErrorMessage,
-                innerException: duplicateKeySqlException);
+                innerException: duplicateKeyMySqlException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetErrorCode(duplicateKeySqlException))
+                broker.GetErrorCode(duplicateKeyMySqlException))
                     .Returns(sqlDuplicateKeyErrorCode);
 
             // when . then
@@ -155,7 +149,7 @@ namespace EFxceptions.Identity.Tests
         }
 
         [Fact]
-        public void ShouldThrowDbUpdateExceptionIfSqlExceptionWasNull()
+        public void ShouldThrowDbUpdateExceptionIfMySqlExceptionWasNull_MySql()
         {
             // given
             var dbUpdateException = new DbUpdateException(null, default(Exception));
@@ -165,13 +159,12 @@ namespace EFxceptions.Identity.Tests
                 this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
 
             this.sqlErrorBrokerMock.Verify(broker =>
-                broker.GetErrorCode(It.IsAny<SqlException>()),
+                broker.GetErrorCode(It.IsAny<MySqlException>()),
                     Times.Never);
         }
 
-        private SqlException CreateSqlException() =>
-            FormatterServices.GetUninitializedObject(typeof(SqlException)) as SqlException;
-
-        private string CreateRandomErrorMessage() => new MnemonicString().GetValue();
+        private MySqlException CreateMyMySqlException() =>
+            FormatterServices.GetUninitializedObject(typeof(MySqlException)) as MySqlException;
+         
     }
 }

--- a/EFxceptions.Tests/Services/EFxceptionServiceTests.cs
+++ b/EFxceptions.Tests/Services/EFxceptionServiceTests.cs
@@ -4,20 +4,20 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
-using System;
-using System.Runtime.Serialization;
 using EFxceptions.Brokers;
 using EFxceptions.Models.Exceptions;
 using EFxceptions.Services;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Moq;
+using System;
+using System.Runtime.Serialization;
 using Tynamix.ObjectFiller;
 using Xunit;
 
 namespace EFxceptions.Tests.Services
 {
-    public class EFxceptionServiceTests
+    public partial class EFxceptionServiceTests
     {
         private readonly Mock<ISqlErrorBroker> sqlErrorBrokerMock;
         private readonly IEFxceptionService efxceptionService;
@@ -41,7 +41,7 @@ namespace EFxceptions.Tests.Services
                 innerException: foreignKeyConstraintConflictException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetSqlErrorCode(foreignKeyConstraintConflictException))
+                broker.GetErrorCode(foreignKeyConstraintConflictException))
                     .Returns(sqlForeignKeyConstraintConflictErrorCode);
 
             // when . then
@@ -62,7 +62,7 @@ namespace EFxceptions.Tests.Services
                 innerException: invalidColumnNameException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetSqlErrorCode(invalidColumnNameException))
+                broker.GetErrorCode(invalidColumnNameException))
                     .Returns(sqlInvalidColumnNameErrorCode);
 
             // when . then
@@ -83,7 +83,7 @@ namespace EFxceptions.Tests.Services
                 innerException: invalidObjectNameException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetSqlErrorCode(invalidObjectNameException))
+                broker.GetErrorCode(invalidObjectNameException))
                     .Returns(sqlInvalidObjectNameErrorCode);
 
             // when . then
@@ -104,7 +104,7 @@ namespace EFxceptions.Tests.Services
                 innerException: foreignKeyConstraintConflictException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetSqlErrorCode(foreignKeyConstraintConflictException))
+                broker.GetErrorCode(foreignKeyConstraintConflictException))
                     .Returns(sqlForeignKeyConstraintConflictErrorCode);
 
             // when . then
@@ -125,7 +125,7 @@ namespace EFxceptions.Tests.Services
                 innerException: duplicateKeySqlException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetSqlErrorCode(duplicateKeySqlException))
+                broker.GetErrorCode(duplicateKeySqlException))
                     .Returns(sqlDuplicateKeyErrorCode);
 
             // when . then
@@ -146,7 +146,7 @@ namespace EFxceptions.Tests.Services
                 innerException: duplicateKeySqlException);
 
             this.sqlErrorBrokerMock.Setup(broker =>
-                broker.GetSqlErrorCode(duplicateKeySqlException))
+                broker.GetErrorCode(duplicateKeySqlException))
                     .Returns(sqlDuplicateKeyErrorCode);
 
             // when . then
@@ -165,7 +165,7 @@ namespace EFxceptions.Tests.Services
                 this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
 
             this.sqlErrorBrokerMock.Verify(broker =>
-                broker.GetSqlErrorCode(It.IsAny<SqlException>()),
+                broker.GetErrorCode(It.IsAny<SqlException>()),
                     Times.Never);
         }
 

--- a/EFxceptions/EFxceptions.csproj
+++ b/EFxceptions/EFxceptions.csproj
@@ -24,6 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" Version="4.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="MySql.Data" Version="8.0.28" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EFxceptions/EFxceptionsContext.cs
+++ b/EFxceptions/EFxceptionsContext.cs
@@ -4,11 +4,11 @@
 // See License.txt in the project root for license information.
 // ---------------------------------------------------------------
 
-using System.Threading;
-using System.Threading.Tasks;
 using EFxceptions.Brokers;
 using EFxceptions.Services;
 using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EFxceptions
 {


### PR DESCRIPTION
``This change fixes issue #31 

The `SqlErrorBroker `should now look like:

```c#
 public class SqlErrorBroker : ISqlErrorBroker
    {
        public int GetErrorCode(DbException exception)
        {
            if (exception is MySqlException mySqlException)
            {
                return mySqlException.Number;
            }

            return ((SqlException)exception).Number;
        }
    }
```
The method `ThrowMeaningfulException` of `EFxceptionService` should now look like:

```c#
 public void ThrowMeaningfulException(DbUpdateException dbUpdateException)
        {
            ValidateInnerException(dbUpdateException);
            DbException dbException = GetDbException(dbUpdateException.InnerException);
            int sqlErrorCode = this.sqlErrorBroker.GetErrorCode(dbException);
            ConvertAndThrowMeaningfulException(sqlErrorCode, dbException.Message);

            throw dbUpdateException;
        }
```
