### PR TITLE
INFRA: Implement EFxceptions Postgres

### DIFF
--- a/EFxceptions.Identity.Postgres.Tests/EFxceptions.Identity.Postgres.Tests.csproj
+++ b/EFxceptions.Identity.Postgres.Tests/EFxceptions.Identity.Postgres.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<ImplicitUsings>disable</ImplicitUsings>
+		<Nullable>disable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="Moq" Version="4.20.72" />
+		<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\EFxceptions.Identity.Postgres\EFxceptions.Identity.Postgres.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
+</Project>

--- a/EFxceptions.Identity.Postgres.Tests/Services/EFxceptionServiceTests.cs
+++ b/EFxceptions.Identity.Postgres.Tests/Services/EFxceptionServiceTests.cs
@@ -1,0 +1,174 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) The Standard Community. All rights reserved.
+// ---------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+using EFxceptions.Identity.Postgres.Brokers.DbErrors;
+using EFxceptions.Models.Exceptions;
+using EFxceptions.Services;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Npgsql;
+using Tynamix.ObjectFiller;
+
+namespace EFxceptions.Identity.Postgres.Tests.Services
+{
+    public class EFxceptionServiceTests
+    {
+        private readonly Mock<IPostgresErrorBroker> sqlErrorBrokerMock;
+        private readonly IEFxceptionService efxceptionService;
+
+        public EFxceptionServiceTests()
+        {
+            this.sqlErrorBrokerMock = new Mock<IPostgresErrorBroker>();
+            this.efxceptionService = new EFxceptionService<PostgresException>(this.sqlErrorBrokerMock.Object);
+        }
+
+        [Fact]
+        public void ShouldThrowDbUpdateExceptionIfErrorCodeIsNotRecognized()
+        {
+            // given
+            int sqlForeignKeyConstraintConflictErrorCode = 0000;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException foreignKeyConstraintConflictException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: foreignKeyConstraintConflictException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(foreignKeyConstraintConflictException))
+                    .Returns(sqlForeignKeyConstraintConflictErrorCode);
+
+            // when . then
+            Assert.Throws<DbUpdateException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowInvalidColumnNameException()
+        {
+            // given
+            int sqlInvalidColumnNameErrorCode = 42703;
+            string randomErrorMessage = CreateRandomErrorMessage();
+            PostgresException invalidColumnNameException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: invalidColumnNameException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(invalidColumnNameException))
+                    .Returns(sqlInvalidColumnNameErrorCode);
+
+            // when . then
+            Assert.Throws<InvalidColumnNameException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowInvalidObjectNameException()
+        {
+            // given
+            int sqlInvalidObjectNameErrorCode = 208;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException invalidObjectNameException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: invalidObjectNameException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(invalidObjectNameException))
+                    .Returns(sqlInvalidObjectNameErrorCode);
+
+            // when . then
+            Assert.Throws<InvalidObjectNameException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowForeignKeyConstraintConflictException()
+        {
+            // given
+            int sqlForeignKeyConstraintConflictErrorCode = 23503;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException foreignKeyConstraintConflictException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: foreignKeyConstraintConflictException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(foreignKeyConstraintConflictException))
+                    .Returns(sqlForeignKeyConstraintConflictErrorCode);
+
+            // when . then
+            Assert.Throws<ForeignKeyConstraintConflictException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowForeignKeyConflictException()
+        {
+            // given
+            int sqlDuplicateKeyErrorCode = 23502;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException duplicateKeyPostgresException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: duplicateKeyPostgresException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(duplicateKeyPostgresException))
+                    .Returns(sqlDuplicateKeyErrorCode);
+
+            // when . then
+            Assert.Throws<ForeignKeyConflictException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowDuplicateKeyException()
+        {
+            // given
+            int sqlDuplicateKeyErrorCode = 23505;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException duplicateKeyPostgresException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: duplicateKeyPostgresException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(duplicateKeyPostgresException))
+                    .Returns(sqlDuplicateKeyErrorCode);
+
+            // when . then
+            Assert.Throws<DuplicateKeyException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowDbUpdateExceptionIfPostgresExceptionWasNull()
+        {
+            // given
+            var dbUpdateException = new DbUpdateException(null, default(Exception));
+
+            // when . then
+            Assert.Throws<DbUpdateException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+
+            this.sqlErrorBrokerMock.Verify(broker =>
+                broker.GetSqlErrorCode(It.IsAny<PostgresException>()),
+                    Times.Never);
+        }
+
+        private PostgresException CreatePostgresException() =>
+            FormatterServices.GetUninitializedObject(typeof(PostgresException)) as PostgresException;
+
+        private string CreateRandomErrorMessage() => new MnemonicString().GetValue();
+    }
+}

--- a/EFxceptions.Identity.Postgres/Brokers/DbErrors/IPostgresErrorBroker.cs
+++ b/EFxceptions.Identity.Postgres/Brokers/DbErrors/IPostgresErrorBroker.cs
@@ -1,0 +1,9 @@
+﻿using EFxceptions.Brokers.DbErrors;
+using Npgsql;
+
+namespace EFxceptions.Identity.Postgres.Brokers.DbErrors
+{
+    public interface IPostgresErrorBroker : IDbErrorBroker<PostgresException>
+    {
+    }
+}

--- a/EFxceptions.Identity.Postgres/Brokers/DbErrors/PostgresErrorBroker.cs
+++ b/EFxceptions.Identity.Postgres/Brokers/DbErrors/PostgresErrorBroker.cs
@@ -1,0 +1,12 @@
+﻿using Npgsql;
+
+namespace EFxceptions.Identity.Postgres.Brokers.DbErrors
+{
+    public class PostgresErrorBroker : IPostgresErrorBroker
+    {
+        public int GetSqlErrorCode(PostgresException exception)
+        {
+            return exception.ErrorCode;
+        }
+    }
+}

--- a/EFxceptions.Identity.Postgres/EFxceptions.Identity.Postgres.csproj
+++ b/EFxceptions.Identity.Postgres/EFxceptions.Identity.Postgres.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+	<Nullable>disable</Nullable>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\EFxceptions.Identity.Core\EFxceptions.Identity.Core.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/EFxceptions.Identity.Postgres/EFxceptionsIdentityContext.cs
+++ b/EFxceptions.Identity.Postgres/EFxceptionsIdentityContext.cs
@@ -1,0 +1,55 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) The Standard Community. All rights reserved.
+// ---------------------------------------------------------------
+
+using System;
+using EFxceptions.Brokers.DbErrors;
+using EFxceptions.Identity.Core;
+using EFxceptions.Identity.Postgres.Brokers.DbErrors;
+using EFxceptions.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+
+namespace EFxceptions.Identity.Postgres
+{
+    public class EFxceptionsIdentityContext<TUser, TRole, TKey>
+        : IdentityDbContextBase<TUser, TRole, TKey, IdentityUserClaim<TKey>, IdentityUserRole<TKey>,
+            IdentityUserLogin<TKey>, IdentityRoleClaim<TKey>, IdentityUserToken<TKey>, PostgresException>
+       where TUser : IdentityUser<TKey>
+       where TRole : IdentityRole<TKey>
+       where TKey : IEquatable<TKey>
+    {
+        public EFxceptionsIdentityContext(DbContextOptions options) : base(options)
+        { }
+
+        protected EFxceptionsIdentityContext()
+        { }
+
+        protected override IDbErrorBroker<PostgresException> CreateErrorBroker() =>
+            new PostgresErrorBroker();
+
+        protected override IEFxceptionService CreateEFxceptionService(
+            IDbErrorBroker<PostgresException> errorBroker) =>
+                new EFxceptionService<PostgresException>(errorBroker);
+    }
+
+    public class EFxceptionsIdentityContext<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken>
+        : IdentityDbContextBase<TUser, TRole, TKey, TUserClaim, TUserRole, TUserLogin, TRoleClaim, TUserToken, PostgresException>
+        where TUser : IdentityUser<TKey>
+        where TRole : IdentityRole<TKey>
+        where TKey : IEquatable<TKey>
+        where TUserClaim : IdentityUserClaim<TKey>
+        where TUserRole : IdentityUserRole<TKey>
+        where TUserLogin : IdentityUserLogin<TKey>
+        where TRoleClaim : IdentityRoleClaim<TKey>
+        where TUserToken : IdentityUserToken<TKey>
+    {
+        protected override IDbErrorBroker<PostgresException> CreateErrorBroker() =>
+            new PostgresErrorBroker();
+
+        protected override IEFxceptionService CreateEFxceptionService(
+            IDbErrorBroker<PostgresException> errorBroker) =>
+                new EFxceptionService<PostgresException>(errorBroker);
+    }
+}

--- a/EFxceptions.Postgres.Tests/EFxceptions.Postgres.Tests.csproj
+++ b/EFxceptions.Postgres.Tests/EFxceptions.Postgres.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+	  <ImplicitUsings>disable</ImplicitUsings>
+	  <Nullable>disable</Nullable>
+	  <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+	<ItemGroup>
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+	<PackageReference Include="Moq" Version="4.20.72" />
+	<PackageReference Include="Tynamix.ObjectFiller" Version="1.5.9" />
+	<PackageReference Include="xunit" Version="2.9.3" />
+	<PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		<PrivateAssets>all</PrivateAssets>
+	</PackageReference>
+	<PackageReference Include="coverlet.collector" Version="6.0.4">
+		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		<PrivateAssets>all</PrivateAssets>
+	</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\EFxceptions.Postgres\EFxceptions.Postgres.csproj" />
+	</ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/EFxceptions.Postgres.Tests/Services/EFxceptionServiceTests.cs
+++ b/EFxceptions.Postgres.Tests/Services/EFxceptionServiceTests.cs
@@ -1,0 +1,174 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) The Standard Community. All rights reserved.
+// ---------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+using EFxceptions.Models.Exceptions;
+using EFxceptions.Postgres.Brokers.DbErrors;
+using EFxceptions.Services;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Npgsql;
+using Tynamix.ObjectFiller;
+
+namespace EFxceptions.Postgres.Tests.Services
+{
+    public class EFxceptionServiceTests
+    {
+        private readonly Mock<IPostgresErrorBroker> sqlErrorBrokerMock;
+        private readonly IEFxceptionService efxceptionService;
+
+        public EFxceptionServiceTests()
+        {
+            this.sqlErrorBrokerMock = new Mock<IPostgresErrorBroker>();
+            this.efxceptionService = new EFxceptionService<PostgresException>(this.sqlErrorBrokerMock.Object);
+        }
+
+        [Fact]
+        public void ShouldThrowDbUpdateExceptionIfErrorCodeIsNotRecognized()
+        {
+            // given
+            int sqlForeignKeyConstraintConflictErrorCode = 0000;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException foreignKeyConstraintConflictException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: foreignKeyConstraintConflictException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(foreignKeyConstraintConflictException))
+                    .Returns(sqlForeignKeyConstraintConflictErrorCode);
+
+            // when . then
+            Assert.Throws<DbUpdateException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowInvalidColumnNameException()
+        {
+            // given
+            int sqlInvalidColumnNameErrorCode = 42703;
+            string randomErrorMessage = CreateRandomErrorMessage();
+            PostgresException invalidColumnNameException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: invalidColumnNameException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(invalidColumnNameException))
+                    .Returns(sqlInvalidColumnNameErrorCode);
+
+            // when . then
+            Assert.Throws<InvalidColumnNameException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowInvalidObjectNameException()
+        {
+            // given
+            int sqlInvalidObjectNameErrorCode = 208;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException invalidObjectNameException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: invalidObjectNameException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(invalidObjectNameException))
+                    .Returns(sqlInvalidObjectNameErrorCode);
+
+            // when . then
+            Assert.Throws<InvalidObjectNameException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowForeignKeyConstraintConflictException()
+        {
+            // given
+            int sqlForeignKeyConstraintConflictErrorCode = 23503;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException foreignKeyConstraintConflictException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: foreignKeyConstraintConflictException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(foreignKeyConstraintConflictException))
+                    .Returns(sqlForeignKeyConstraintConflictErrorCode);
+
+            // when . then
+            Assert.Throws<ForeignKeyConstraintConflictException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowForeignKeyConflictException()
+        {
+            // given
+            int sqlDuplicateKeyErrorCode = 23502;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException duplicateKeyPostgresException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: duplicateKeyPostgresException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(duplicateKeyPostgresException))
+                    .Returns(sqlDuplicateKeyErrorCode);
+
+            // when . then
+            Assert.Throws<ForeignKeyConflictException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowDuplicateKeyException()
+        {
+            // given
+            int sqlDuplicateKeyErrorCode = 23505;
+            string randomErrorMessage = new MnemonicString().GetValue();
+            PostgresException duplicateKeyPostgresException = CreatePostgresException();
+
+            var dbUpdateException = new DbUpdateException(
+                message: randomErrorMessage,
+                innerException: duplicateKeyPostgresException);
+
+            this.sqlErrorBrokerMock.Setup(broker =>
+                broker.GetSqlErrorCode(duplicateKeyPostgresException))
+                    .Returns(sqlDuplicateKeyErrorCode);
+
+            // when . then
+            Assert.Throws<DuplicateKeyException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+        }
+
+        [Fact]
+        public void ShouldThrowDbUpdateExceptionIfPostgresExceptionWasNull()
+        {
+            // given
+            var dbUpdateException = new DbUpdateException(null, default(Exception));
+
+            // when . then
+            Assert.Throws<DbUpdateException>(() =>
+                this.efxceptionService.ThrowMeaningfulException(dbUpdateException));
+
+            this.sqlErrorBrokerMock.Verify(broker =>
+                broker.GetSqlErrorCode(It.IsAny<PostgresException>()),
+                    Times.Never);
+        }
+
+        private PostgresException CreatePostgresException() =>
+            FormatterServices.GetUninitializedObject(typeof(PostgresException)) as PostgresException;
+
+        private string CreateRandomErrorMessage() => new MnemonicString().GetValue();
+    }
+}

--- a/EFxceptions.Postgres/Brokers/DbErrors/IPostgresErrorBroker.cs
+++ b/EFxceptions.Postgres/Brokers/DbErrors/IPostgresErrorBroker.cs
@@ -1,0 +1,9 @@
+﻿using EFxceptions.Brokers.DbErrors;
+using Npgsql;
+
+namespace EFxceptions.Postgres.Brokers.DbErrors
+{
+    public interface IPostgresErrorBroker : IDbErrorBroker<PostgresException>
+    {
+    }
+}

--- a/EFxceptions.Postgres/Brokers/DbErrors/PostgresErrorBroker.cs
+++ b/EFxceptions.Postgres/Brokers/DbErrors/PostgresErrorBroker.cs
@@ -1,0 +1,12 @@
+﻿using Npgsql;
+
+namespace EFxceptions.Postgres.Brokers.DbErrors
+{
+    public class PostgresErrorBroker : IPostgresErrorBroker
+    {
+        public int GetSqlErrorCode(PostgresException exception)
+        {
+            return int.Parse(exception.SqlState);
+        }
+    }
+}

--- a/EFxceptions.Postgres/EFxceptions.Postgres.csproj
+++ b/EFxceptions.Postgres/EFxceptions.Postgres.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EFxceptions.Core\EFxceptions.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/EFxceptions.Postgres/EFxceptionsContext.cs
+++ b/EFxceptions.Postgres/EFxceptionsContext.cs
@@ -1,0 +1,22 @@
+﻿// ---------------------------------------------------------------
+// Copyright (c) The Standard Community. All rights reserved.
+// ---------------------------------------------------------------
+
+using EFxceptions.Brokers.DbErrors;
+using EFxceptions.Core;
+using EFxceptions.Postgres.Brokers.DbErrors;
+using EFxceptions.Services;
+using Npgsql;
+
+namespace EFxceptions.Postgres
+{
+    public class EFxceptionsContext : DbContextBase<PostgresException>
+    {
+        protected override IDbErrorBroker<PostgresException> CreateErrorBroker() =>
+            new PostgresErrorBroker();
+
+        protected override IEFxceptionService CreateEFxceptionService(
+            IDbErrorBroker<PostgresException> errorBroker) =>
+                new EFxceptionService<PostgresException>(errorBroker);
+    }
+}

--- a/EFxceptions.Shared/EFxceptions.Shared.projitems
+++ b/EFxceptions.Shared/EFxceptions.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Brokers\DbErrors\IDbErrorBroker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Exceptions\DuplicateKeyWithUniqueIndexException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Exceptions\DuplicateKeyException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)models\exceptions\ForeignKeyConflictException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Exceptions\ForeignKeyConstraintConflictException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Exceptions\InvalidColumnNameException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Models\Exceptions\InvalidObjectNameException.cs" />

--- a/EFxceptions.Shared/Models/Exceptions/ForeignKeyConflictException.cs
+++ b/EFxceptions.Shared/Models/Exceptions/ForeignKeyConflictException.cs
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------
+// Copyright (c) The Standard Community. All rights reserved.
+// ---------------------------------------------------------------
+
+using System;
+
+namespace EFxceptions.Models.Exceptions
+{
+    public class ForeignKeyConflictException : Exception
+    {
+        public ForeignKeyConflictException(string message) : base(message) { }
+    }
+}

--- a/EFxceptions.Shared/Services/EFxceptionService.Exceptions.cs
+++ b/EFxceptions.Shared/Services/EFxceptionService.Exceptions.cs
@@ -22,6 +22,15 @@ namespace EFxceptions.Services
                     throw new DuplicateKeyWithUniqueIndexException(message);
                 case 2627:
                     throw new DuplicateKeyException(message);
+
+                case 23505:
+                    throw new DuplicateKeyException(message);
+                case 23503:
+                    throw new ForeignKeyConstraintConflictException(message);
+                case 23502:
+                    throw new ForeignKeyConflictException(message);
+                case 42703:
+                    throw new InvalidColumnNameException(message);
             }
         }
     }

--- a/EFxceptions.sln
+++ b/EFxceptions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31912.275
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11123.170
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFxceptions", "EFxceptions\EFxceptions.csproj", "{A379F3E6-AF92-4EB6-BA07-FE188DF0AE2D}"
 EndProject
@@ -42,6 +42,16 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFxceptions.Identity.SQLite", "EFxceptions.Identity.SQLite\EFxceptions.Identity.SQLite.csproj", "{AD934287-74E7-4D73-8DE3-70BFAB4A3C34}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFxceptions.Identity.SQLite.Tests", "EFxceptions.Identity.SQLite.Tests\EFxceptions.Identity.SQLite.Tests.csproj", "{3FF9635F-353F-4383-8C95-F41ADB90C405}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Postgres", "Postgres", "{B8FA76E5-0148-4DF5-B9ED-A108AD70A4CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFxceptions.Postgres", "EFxceptions.Postgres\EFxceptions.Postgres.csproj", "{FF64563E-8BB0-47FE-B3D1-4FA67A38A554}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFxceptions.Postgres.Tests", "EFxceptions.Postgres.Tests\EFxceptions.Postgres.Tests.csproj", "{A34B44E7-744B-436C-BC3A-9E1AD12511ED}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFxceptions.Identity.Postgres", "EFxceptions.Identity.Postgres\EFxceptions.Identity.Postgres.csproj", "{30BD8EC4-E1BC-4D62-95B9-45DC3D764167}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EFxceptions.Identity.Postgres.Tests", "EFxceptions.Identity.Postgres.Tests\EFxceptions.Identity.Postgres.Tests.csproj", "{4081A816-8C60-4F05-B81B-EB1D0A3D4AEF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -109,6 +119,22 @@ Global
 		{3FF9635F-353F-4383-8C95-F41ADB90C405}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3FF9635F-353F-4383-8C95-F41ADB90C405}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3FF9635F-353F-4383-8C95-F41ADB90C405}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF64563E-8BB0-47FE-B3D1-4FA67A38A554}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF64563E-8BB0-47FE-B3D1-4FA67A38A554}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF64563E-8BB0-47FE-B3D1-4FA67A38A554}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF64563E-8BB0-47FE-B3D1-4FA67A38A554}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A34B44E7-744B-436C-BC3A-9E1AD12511ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A34B44E7-744B-436C-BC3A-9E1AD12511ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A34B44E7-744B-436C-BC3A-9E1AD12511ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A34B44E7-744B-436C-BC3A-9E1AD12511ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30BD8EC4-E1BC-4D62-95B9-45DC3D764167}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30BD8EC4-E1BC-4D62-95B9-45DC3D764167}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30BD8EC4-E1BC-4D62-95B9-45DC3D764167}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30BD8EC4-E1BC-4D62-95B9-45DC3D764167}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4081A816-8C60-4F05-B81B-EB1D0A3D4AEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4081A816-8C60-4F05-B81B-EB1D0A3D4AEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4081A816-8C60-4F05-B81B-EB1D0A3D4AEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4081A816-8C60-4F05-B81B-EB1D0A3D4AEF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -128,6 +154,10 @@ Global
 		{2CFB9357-7A83-4877-9D5B-6481AFA8F2AD} = {727CF9AE-D1CD-44DE-9F95-735973F1B04F}
 		{AD934287-74E7-4D73-8DE3-70BFAB4A3C34} = {727CF9AE-D1CD-44DE-9F95-735973F1B04F}
 		{3FF9635F-353F-4383-8C95-F41ADB90C405} = {727CF9AE-D1CD-44DE-9F95-735973F1B04F}
+		{FF64563E-8BB0-47FE-B3D1-4FA67A38A554} = {B8FA76E5-0148-4DF5-B9ED-A108AD70A4CA}
+		{A34B44E7-744B-436C-BC3A-9E1AD12511ED} = {B8FA76E5-0148-4DF5-B9ED-A108AD70A4CA}
+		{30BD8EC4-E1BC-4D62-95B9-45DC3D764167} = {B8FA76E5-0148-4DF5-B9ED-A108AD70A4CA}
+		{4081A816-8C60-4F05-B81B-EB1D0A3D4AEF} = {B8FA76E5-0148-4DF5-B9ED-A108AD70A4CA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DCA463B2-B2AC-41DD-8F64-4D9D5C9C1E1A}

--- a/EFxceptionsContext.cs
+++ b/EFxceptionsContext.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+public class Class1
+{
+	public Class1()
+	{
+	}
+}


### PR DESCRIPTION
This pull request introduces initial support for PostgreSQL in the EFxceptions library, including both the main and Identity packages, along with comprehensive test projects. The changes add new context classes, error brokers for PostgreSQL exceptions, and xUnit-based unit tests to ensure correct exception handling and translation. The projects are set up to target .NET 9 and reference the necessary dependencies for PostgreSQL, EFxceptions core libraries, and testing.

**PostgreSQL Support and Integration**

* Added new context classes `EFxceptionsContext` and `EFxceptionsIdentityContext` for PostgreSQL, implementing the required error broker and exception service logic to integrate with EFxceptions core. (`EFxceptions.Postgres/EFxceptionsContext.cs` [[1]](diffhunk://#diff-2851ecdd23f7504f1ae08c30489895a58e7c29932b2cf5001299493657392a08R1-R22) `EFxceptions.Identity.Postgres/EFxceptionsIdentityContext.cs` [[2]](diffhunk://#diff-d3dbdcb94ab619783f6a172c6f25202b86aec2ad8bd6ce16b77f64d4c0e888eaR1-R55)
* Implemented `IPostgresErrorBroker` and `PostgresErrorBroker` to extract SQL error codes from `PostgresException`, enabling meaningful exception translation. (`EFxceptions.Postgres/Brokers/DbErrors/IPostgresErrorBroker.cs` [[1]](diffhunk://#diff-e70bd2c5c72e261cd8ff3163df24261ec7a89c9ddc77b42299c256857ab45ef0R1-R9) `EFxceptions.Postgres/Brokers/DbErrors/PostgresErrorBroker.cs` [[2]](diffhunk://#diff-a3ff80783341cc7e43453bb52d3cb8407af99195db9a583729229ef891bb8ad9R1-R12) `EFxceptions.Identity.Postgres/Brokers/DbErrors/IPostgresErrorBroker.cs` [[3]](diffhunk://#diff-14cc448857258e3c3f1c0e39f69b967ad3634db7f5f19b9ffb5f05b88baf6e9eR1-R9) `EFxceptions.Identity.Postgres/Brokers/DbErrors/PostgresErrorBroker.cs` [[4]](diffhunk://#diff-a1c7407e10cce5c759979426183d18a3546e4aab043625fa3e80eec6e66cc9feR1-R12)

**Testing Infrastructure**

* Added new test projects for both main and Identity PostgreSQL packages, including all necessary dependencies and references for xUnit, Moq, and object fillers. (`EFxceptions.Postgres.Tests/EFxceptions.Postgres.Tests.csproj` [[1]](diffhunk://#diff-832eadd367ea15d29d447bef727c93f9ef7cc428a8b2cae42dcde0dd708ab2edR1-R33) `EFxceptions.Identity.Postgres.Tests/EFxceptions.Identity.Postgres.Tests.csproj` [[2]](diffhunk://#diff-10a7bc71f65b68b6b74039536a7cf559b9f6ad406508b0bbecd1de1ebfbe356cR1-R32)
* Implemented comprehensive unit tests for `EFxceptionService` using PostgreSQL exceptions to verify correct exception mapping and error handling logic. (`EFxceptions.Postgres.Tests/Services/EFxceptionServiceTests.cs` [[1]](diffhunk://#diff-622842726e81f1ef1ec3640e62853e92eaac43ef5253255b38270f778c335018R1-R174) `EFxceptions.Identity.Postgres.Tests/Services/EFxceptionServiceTests.cs` [[2]](diffhunk://#diff-348055578bc4f10fd53ddffe9db80c39fe44874a645140fda62a0212ff0a9e16R1-R174)

**Project Configuration**

* Added new project files for PostgreSQL support, targeting .NET 9 and referencing the relevant EFxceptions and PostgreSQL packages. (`EFxceptions.Postgres/EFxceptions.Postgres.csproj` [[1]](diffhunk://#diff-14b07955e9f9361c6e3ccf777aedcb3360ed99a4b17d13ac148ebd5a2a34e077R1-R17) `EFxceptions.Identity.Postgres/EFxceptions.Identity.Postgres.csproj` [[2]](diffhunk://#diff-852c3f61886888a9d848956de17bfc0c007d2e410db7463a06b3456995bb21a6R1-R17)